### PR TITLE
Added support for sub and superscripts

### DIFF
--- a/org-appear.el
+++ b/org-appear.el
@@ -154,9 +154,10 @@ TODO: Extracted info."
   (let* ((elem-type (car elem))
 	 (elem-start (org-element-property :begin elem))
 	 (elem-end (org-element-property :end elem))
+	 (elem-content-start (org-element-property :contents-begin elem))
+	 (elem-content-end (org-element-property :contents-end elem))
 	 (post-elem-spaces (org-element-property :post-blank elem))
-	 (elem-end-real (- elem-end post-elem-spaces))
-	 (elem-has-brackets (org-element-property :use-brackets-p elem)))
+	 (elem-end-real (- elem-end post-elem-spaces)))
     (cond ((member elem-type '(bold
 			       italic
 			       underline
@@ -170,17 +171,11 @@ TODO: Extracted info."
 		 'type 'emph))
 	  ((member elem-type '(subscript
 			       superscript))
-	   (if elem-has-brackets
-	       (list 'start elem-start
-		     'end elem-end-real
-		     'visible-start (+ elem-start 2)
-		     'visible-end (1- elem-end-real)
-		     'type 'subscript)
-	     (list 'start elem-start
-		   'end elem-end-real
-		   'visible-start (1+ elem-start)
-		   'visible-end elem-end-real
-		   'type 'subscript)))
+	   (list 'start elem-start
+		 'end elem-end-real
+		 'visible-start elem-content-start
+		 'visible-end elem-content-end
+		 'type 'subscript))
 	  ((member elem-type '(latex-fragment
 			       latex-environmet))
 	   (list 'start elem-start

--- a/org-appear.el
+++ b/org-appear.el
@@ -182,17 +182,15 @@ TODO: Extracted info."
 		 'end elem-end-real
 		 'type 'latex))
 	  ((equal elem-type 'link)
-	   (let ((visible-start (org-element-property :contents-begin elem))
-		 (visible-end (org-element-property :contents-end elem)))
 	     (list 'start elem-start
 		   'end elem-end-real
-		   'visible-start (if visible-start
-				      visible-start
+		   'visible-start (if elem-content-start
+				      elem-content-start
 				    (+ elem-start 2))
-		   'visible-end (if visible-end
-				    visible-end
+		   'visible-end (if elem-content-end
+				    elem-content-end
 				  (- elem-end-real 2))
-		   'type 'link)))
+		   'type 'link))
 	  (t nil))))
 
 (defun org-appear--enable (elem)


### PR DESCRIPTION
I added support for Sub- and Superscript markers. I used the new `org-togglers` branch, since the new infrastructure made it very easy to implement. (Thank you for that!)

I only encountered one small error: When you have something like `word1_{sub1} word2` and then remove the `{`, the first letter of `sub1` and the space between the words is hidden. (Since then it technically isn't a valid fragment anymore, so it hides the "previous" fragment, not knowing, that the brace disappeared and the characters moved.)
I haven't found an elegant way to fix this. The only solution that I could think of, is to, instead of saving the element context in `org-appear--prev-frag`, we simply save the previous `point` and reevaluate the element context in the post-command-hook. This way we can react to changes in the current fragment.