### PR TITLE
Entity Toggling

### DIFF
--- a/org-appear.el
+++ b/org-appear.el
@@ -220,11 +220,11 @@ Return nil if element is not supported by `org-appear-mode'."
 	 (visible-end (plist-get elem-at-point :visible-end))
 	 (parent (plist-get elem-at-point :parent)))
     (with-silent-modifications
-			(if (eq elem-type 'entity)
-					(remove-text-properties start end '(composition))
-				(remove-text-properties start visible-start '(invisible org-link))
-				(remove-text-properties visible-end end '(invisible org-link))))
-		;; To minimise distraction from moving text,
+      (if (eq elem-type 'entity)
+	  (remove-text-properties start end '(composition))
+	(remove-text-properties start visible-start '(invisible org-link))
+	(remove-text-properties visible-end end '(invisible org-link))))
+    ;; To minimise distraction from moving text,
     ;; always keep parent emphasis markers visible
     (when parent
       (org-appear--show-invisible parent))))
@@ -239,8 +239,8 @@ Return nil if element is not supported by `org-appear-mode'."
     ;; Call `font-lock-ensure' after flushing to prevent `jit-lock-mode'
     ;; from refontifying the next element entered
     (font-lock-ensure start end)
-		(when (eq elem-type 'entity)
-			(goto-char start))))
+    (when (eq elem-type 'entity)
+      (goto-char start))))
 
 (provide 'org-appear)
 ;;; org-appear.el ends here


### PR DESCRIPTION
Based upon the request from @japhir at #2, I implemented a very simple first approach of entity toggling. It seemed to work fine, but I did not really had the time to further test this, so there might still be some bugs.
I tried not to write a new function for this, but instead implemented this with the functionality currently available, reusing as much code as possible.

But I have found one bug: After disabling the Org-Appear Mode, the cursor behaves wierdly, when moving over previously decomposed entities. I don't really know what is causing this, since the composition seems to be reapplied correctly, so the bug is maybe not even related to Org-Mode, but instead to movement functions? Maybe a look at `prettify-symbols-mode` (which does more or less the same thing as Entity Toggling) will help to understand what is happening here.