### PR TITLE
added ability to toggle keywords

### DIFF
--- a/org-appear.el
+++ b/org-appear.el
@@ -175,7 +175,10 @@ Return nil if element is not supported by `org-appear-mode'."
     (let ((elem-type (car elem))
 	  (elem-end (- (org-element-property :end elem)
 		       (1- (org-element-property :post-blank elem))))
-	  (elem-ignorep (string= (org-element-property :type elem) "cite")))
+	  (elem-ignorep (or (string= (org-element-property :type elem) "cite")
+			    (when-let ((key (org-element-property :key elem)))
+			      (not (member (downcase key)
+					   (mapcar (lambda (atom) (format "%s" atom)) org-hidden-keywords)))))))
       (if (and (memq elem-type org-appear-elements)
 	       (< (point) elem-end)     ; Ignore post-element whitespace
 	       (not elem-ignorep))      ; Ignore specific elements

--- a/org-appear.el
+++ b/org-appear.el
@@ -255,11 +255,11 @@ Return nil if element cannot be parsed."
        ((eq elem-type 'entity) (remove-text-properties start end '(composition)))
        ((eq elem-type 'keyword) (remove-text-properties start end '(invisible org-link)))
        (t (remove-text-properties start visible-start '(invisible org-link))
-	  (remove-text-properties visible-end end '(invisible org-link))))
+	  (remove-text-properties visible-end end '(invisible org-link)))))
     ;; To minimise distraction from moving text,
     ;; always keep parent emphasis markers visible
     (when parent
-      (org-appear--show-invisible parent)))))
+      (org-appear--show-invisible parent))))
 
 (defun org-appear--hide-invisible (elem)
   "Flush fontification of element ELEM."


### PR DESCRIPTION
I heard my name was called, so I quickly did some coding in my free time and implemented keywords. (This closes #22 btw.)
One small caveat I found however: Since the keywords are normally not visible, Org-Mode nether bothers to apply the correct face to it, so when we unhide it, it is displayes with the default face and not the custom `org-document-info-keyword`.