### PR TITLE
Tabularise customisation options for easy reference

### DIFF
--- a/README.org
+++ b/README.org
@@ -37,7 +37,7 @@ The package can be enabled interactively or automatically on org-mode start-up:
 
 #+end_src
 
-** Customisation
+** Customization
 
 By default, toggling is instantaneous and only emphasis markers are toggled. The following custom variables can be changed to enable/disable functionality.
 

--- a/README.org
+++ b/README.org
@@ -15,7 +15,7 @@ Make invisible parts of Org elements appear visible.
 
 The easiest way to install ~org-appear~ is from MELPA, using your favourite package manager or ~package-install~. For Guix users, ~org-appear~ is also available in the official GNU Guix channel.
 
-** Manual installation
+*** Straight.el
 
 With [[https://github.com/raxod502/straight.el][straight.el]], simply put the following line in ~init.el~:
 
@@ -37,15 +37,22 @@ The package can be enabled interactively or automatically on org-mode start-up:
 
 #+end_src
 
-By default, toggling is instantaneous and only emphasis markers are toggled. The following custom variables can be changed to enable additional functionality.
+** Customisation
 
-- org-appear-autolinks :: if non-nil, toggle links
-- org-appear-autosubmarkers :: if non-nil, toggle subscripts and superscripts
-- org-appear-autoentities :: if non-nil, toggle Org entitites
-- org-appear-autokeywords :: if non-nil, toggle keywords in ~org-hidden-keywords~
-- org-appear-delay :: seconds of delay before toggling
+By default, toggling is instantaneous and only emphasis markers are toggled. The following custom variables can be changed to enable/disable functionality.
 
+| Variable                  | Description                                     | Default |
+|---------------------------+-------------------------------------------------+---------|
+| org-appear-autoemphasis   | Non-nil toggles emphasis and verbatim markers   | t       |
+| org-appear-autosubmarkers | Non-nil toggles subscripts and superscripts     | nil     |
+| org-appear-autoentities   | Non-nil toggles [[https://orgmode.org/manual/Special-Symbols.html][org entities]].                   | nil     |
+| org-appear-autolinks      | Non-nil toggles links                           | nil     |
+| org-appear-autokeywords   | Non-nil toggles keywords in ~org-hidden-keywords~ | nil     |
+| org-appear-delay          | Delay in seconds before toggling                | 0.0     |
+
+#+BEGIN_QUOTE
 If Org mode custom variables that control visibility of elements are configured to show hidden parts, the respective ~org-appear~ settings do not have an effect.
+#+END_QUOTE
 
 ** Acknowledgements
 


### PR DESCRIPTION
Saw an issue where someone wasn't able to find the customization options easily. A table of custom variables is much easier to parse.