### PR TITLE
Keep current element open after manual stop

### DIFF
--- a/org-appear.el
+++ b/org-appear.el
@@ -227,12 +227,8 @@ It signals that elements in the current buffer must be toggled."
   (setq org-appear--do-buffer 't))
 
 (defun org-appear-manual-stop ()
-  "Signal that elements in the current buffer must no longer be toggled.
-Cleanup current element, if any."
-  (when-let ((current-elem (org-appear--current-elem)))
-    (org-appear--hide-invisible current-elem))
-  (setq org-appear--do-buffer nil)
-  (setq org-appear--elem-toggled nil))
+  "Signal that elements in the current buffer must no longer be toggled."
+  (setq org-appear--do-buffer nil))
 
 (defun org-appear--pre-cmd ()
   "This function is executed by `pre-command-hook' in `org-appear-mode'.

--- a/org-appear.el
+++ b/org-appear.el
@@ -93,6 +93,12 @@ Does not have an effect if `org-hidden-keywords' is nil."
   :type 'number
   :group 'org-appear)
 
+(defcustom org-appear-manual-linger nil
+  "Whether to hide the element on manual stop.
+If true, hide upon navigating away."
+  :type 'boolean
+  :group 'org-appear)
+
 (defvar-local org-appear--timer nil
   "Current active timer.")
 
@@ -228,6 +234,10 @@ It signals that elements in the current buffer must be toggled."
 
 (defun org-appear-manual-stop ()
   "Signal that elements in the current buffer must no longer be toggled."
+  (when (not org-appear-manual-linger)
+    (when-let ((current-elem (org-appear--current-elem)))
+      (org-appear--hide-invisible current-elem))
+    (setq org-appear--elem-toggled nil))
   (setq org-appear--do-buffer nil))
 
 (defun org-appear--pre-cmd ()


### PR DESCRIPTION
After using the feature added in #38 for a bit, I experimented with this change and decided I liked it better. I may not understand the full context here, so maybe this is not a good change for everyone, but the reason I moved toward it is because I am so heavily dependent on modal editing, that even when I move around a little bit in a link, I habitually hit escape and move with `hjkl`. So suppose I hit `i` in order to edit a link. The link opens, and I am happy; but my cursor is on the display text. Okay, that makes sense to me, since that was the part that was visible. So I move my cursor over to where the link is, and make an edit. However, when I go to move my cursor, I habitually <kbd>ESC</kbd> from insert mode and start hitting `h` or `b` or the like. Without this change, however, as soon as I hit <kbd>ESC</kbd>, the link closes again, because [I have added](https://github.com/syl20bnr/spacemacs/pull/15284/files#diff-38da31b467c7e3de40b2cffd9f474b81e117b5636a8391892599f6d2568bcd77R1033) the manual stop function to the evil insert state exit hook.

I'm curious what you think. Am I overlooking some important factor here?