### PR TITLE
Toggling in Latex

### DIFF
--- a/README.org
+++ b/README.org
@@ -43,6 +43,7 @@ By default, toggling is instantaneous and only emphasis markers are toggled. The
 - org-appear-autosubmarkers :: if non-nil, toggle subscripts and superscripts
 - org-appear-autoentities :: if non-nil, toggle Org entitites
 - org-appear-autokeywords :: if non-nil, toggle keywords in ~org-hidden-keywords~
+- org-appear-inside-latex :: if non-nil, also toggle entities and subscripts / superscripts in Latex fragments
 - org-appear-delay :: seconds of delay before toggling
 - org-appear-trigger :: when to toggle elements
 

--- a/org-appear.el
+++ b/org-appear.el
@@ -89,8 +89,9 @@ Does not have an effect if `org-hidden-keywords' is nil."
   :group 'org-appear)
 
 (defcustom org-appear-inside-latex nil
-  "Also applies toggling of subscripts and superscripts (if `org-appear-autosubmarkers' is non-nil)
-and toggling of entities (if `org-appear-autoentities' is non-nil) inside Latex fragments."
+  "Also applies toggling of subscripts and superscripts (if
+`org-appear-autosubmarkers' is non-nil) and toggling of entities (if
+`org-appear-autoentities' is non-nil) inside Latex fragments and environments."
   :type 'boolean
   :group 'org-appear)
 
@@ -156,7 +157,7 @@ nil if the cursor was not on an element.")
 	(entity-elements '(entity))
 	(link-elements '(link))
 	(keyword-elements '(keyword))
-	(latex-elements '(latex-fragment)))
+	(latex-elements '(latex-fragment latex-environment)))
 
     ;; HACK: is there a better way to do this?
     (setq-local org-appear--prev-elem nil)
@@ -299,7 +300,7 @@ Return nil if element cannot be parsed."
 			  'link)
 			 ((eq elem-type 'keyword)
 			  'keyword)
-			 ((eq elem-type 'latex-fragment)
+			 ((memq elem-type '(latex-fragment latex-environment))
 			  'latex-fragment)
 			 (t nil)))
 	 (elem-start (org-element-property :begin elem))
@@ -335,7 +336,7 @@ Return nil if element cannot be parsed."
     (with-silent-modifications
       (cond ((eq elem-type 'entity)
 	     (decompose-region start end))
-	    ((eq elem-type 'latex-fragment)
+	    ((memq elem-type '(latex-fragment latex-environment))
 	     (when org-appear-autosubmarkers
 	       (remove-text-properties start end '(invisible)))
 	     (when org-appear-autoentities
@@ -375,7 +376,7 @@ When RENEW is non-nil, obtain element at point instead."
 	(cond ((eq elem-type 'entity)
 	       (compose-region start end (org-element-property :utf-8 elem))
 	       (font-lock-flush start end))
-	      ((memq elem-type '(keyword latex-fragment))
+	      ((memq elem-type '(keyword latex-fragment latex-environment))
 	       (font-lock-flush start end))
 	      (t
 	       (put-text-property start visible-start 'invisible 'org-link)

--- a/org-appear.el
+++ b/org-appear.el
@@ -335,7 +335,8 @@ Return nil if element cannot be parsed."
       (cond ((eq elem-type 'entity)
 	     (decompose-region start end))
 	    ((eq elem-type 'latex-fragment)
-	     (remove-text-properties start end '(invisible composition)))
+	     (remove-text-properties start end '(invisible composition))
+	     (decompose-region start end))
 	    ((eq elem-type 'keyword)
 	     (remove-text-properties start end '(invisible org-link)))
 	    (t
@@ -372,6 +373,8 @@ When RENEW is non-nil, obtain element at point instead."
 	       (compose-region start end (org-element-property :utf-8 elem))
 	       (font-lock-flush start end))
 	      ((eq elem-type 'keyword)
+	       (font-lock-flush start end))
+	      ((eq elem-type 'latex-fragment)
 	       (font-lock-flush start end))
 	      (t
 	       (put-text-property start visible-start 'invisible 'org-link)

--- a/org-appear.el
+++ b/org-appear.el
@@ -89,9 +89,9 @@ Does not have an effect if `org-hidden-keywords' is nil."
   :group 'org-appear)
 
 (defcustom org-appear-inside-latex nil
-  "Also applies toggling of subscripts and superscripts (if
-`org-appear-autosubmarkers' is non-nil) and toggling of entities (if
-`org-appear-autoentities' is non-nil) inside Latex fragments and environments."
+  "Also applies toggling inside Latex fragments and environments.
+Sub- and superscript markers are toggled if `org-appear-autosubmarkers' is
+non-nil.  Entities are toggled if `org-appear-autoentities' is non-nil."
   :type 'boolean
   :group 'org-appear)
 


### PR DESCRIPTION
I added an option to toggle submarkers and entites inside Latex Fragments.
The toggling uses the variables `org-appear-autosubmarkers` and `org-appear-autoentities` to controll toggling further.
Unfortunatly, since the org-element API only returns a whole latex fragments and not single elements, it allways toggles the whole fragment. For me this is however not an issue. 