### PR TITLE
Toggle just brackets around links

### DIFF
--- a/org-appear.el
+++ b/org-appear.el
@@ -332,6 +332,15 @@ Return nil if element cannot be parsed."
 	     (decompose-region start end))
 	    ((eq elem-type 'keyword)
 	     (remove-text-properties start end '(invisible org-link)))
+            ((and (eq elem-type 'link)
+                  (eq org-appear-autolinks 'just-brackets)
+                  (< start visible-start visible-end end))
+             (remove-text-properties visible-end
+                                     (1+ visible-end)
+                                     '(invisible org-link))
+             (remove-text-properties (1- visible-start)
+                                     visible-start
+                                     '(invisible org-link)))
 	    (t
 	     (remove-text-properties start visible-start '(invisible org-link))
 	     (remove-text-properties visible-end end '(invisible org-link)))))))

--- a/org-appear.el
+++ b/org-appear.el
@@ -77,7 +77,9 @@ Does not have an effect if `org-pretty-entities' is nil."
   :group 'org-appear)
 
 (defcustom org-appear-autolinks nil
-  "Non-nil enables automatic toggling of links.
+  "Non-nil enables automatic toggling of links.  If set to
+the symbol `just-brackets', links will be shown with brackets
+around them without showing the link target.
 Does not have an effect if `org-link-descriptive' is nil."
   :type 'boolean
   :group 'org-appear)

--- a/org-appear.el
+++ b/org-appear.el
@@ -81,7 +81,9 @@ Does not have an effect if `org-pretty-entities' is nil."
 If set to the symbol `just-brackets', links will be shown with
 brackets around them without showing the link target.  Does not
 have an effect if `org-link-descriptive' is nil."
-  :type '(choice boolean (const just-brackets))
+  :type '(choice (const :tag "Ignore links" nil)
+		 (const :tag "Toggle full link" t)
+		 (const :tag "Toggle brackets" just-brackets))
   :group 'org-appear)
 
 (defcustom org-appear-autokeywords nil

--- a/org-appear.el
+++ b/org-appear.el
@@ -77,11 +77,11 @@ Does not have an effect if `org-pretty-entities' is nil."
   :group 'org-appear)
 
 (defcustom org-appear-autolinks nil
-  "Non-nil enables automatic toggling of links.  If set to
-the symbol `just-brackets', links will be shown with brackets
-around them without showing the link target.
-Does not have an effect if `org-link-descriptive' is nil."
-  :type 'boolean
+  "Non-nil enables automatic toggling of links.
+If set to the symbol `just-brackets', links will be shown with
+brackets around them without showing the link target.  Does not
+have an effect if `org-link-descriptive' is nil."
+  :type '(choice boolean (const just-brackets))
   :group 'org-appear)
 
 (defcustom org-appear-autokeywords nil
@@ -334,15 +334,14 @@ Return nil if element cannot be parsed."
 	     (decompose-region start end))
 	    ((eq elem-type 'keyword)
 	     (remove-text-properties start end '(invisible org-link)))
-            ((and (eq elem-type 'link)
-                  (eq org-appear-autolinks 'just-brackets)
-                  (< start visible-start visible-end end))
-             (remove-text-properties visible-end
-                                     (1+ visible-end)
-                                     '(invisible org-link))
-             (remove-text-properties (1- visible-start)
-                                     visible-start
-                                     '(invisible org-link)))
+	    ((and (eq elem-type 'link)
+		  (eq org-appear-autolinks 'just-brackets))
+	     (remove-text-properties visible-end
+				     (1+ visible-end)
+				     '(invisible org-link))
+	     (remove-text-properties (1- visible-start)
+				     visible-start
+				     '(invisible org-link)))
 	    (t
 	     (remove-text-properties start visible-start '(invisible org-link))
 	     (remove-text-properties visible-end end '(invisible org-link)))))))


### PR DESCRIPTION
Hey!  Nice work here!  I really like this package.  It solves a major gripe with vanilla org-mode in a really elegant way :)
I was wondering if you can adopt this small enhancement, though.

Showing everything inside a link can be disorienting, as URLs tend to be long, and showing them shifts all subsequent text by many characters.  The URL is also usually not interesting: it's just a technical detail of a link which is rarely inspected or updated.

This PR allows `org-appear-autolinks` to be set to `'just-brackets`, which instructs org-appear to show just a pair of brackets around a link under point, and no more.  This way, I get solid visual feedback on whether I'm typing inside or outside the link text, without seeing the link expand into a huge blob.  If I ever need to view/edit the URL, I can still use `org-insert-link`.