### PR TITLE
Document Org variables that should be set to hide elements

### DIFF
--- a/README.org
+++ b/README.org
@@ -39,10 +39,11 @@ The package can be enabled interactively or automatically on Org mode start-up:
 
 By default, toggling is instantaneous and only emphasis markers are toggled. The following custom variables can be changed to enable additional functionality.
 
-- org-appear-autolinks :: if non-nil, toggle links
-- org-appear-autosubmarkers :: if non-nil, toggle subscripts and superscripts
-- org-appear-autoentities :: if non-nil, toggle Org entitites
-- org-appear-autokeywords :: if non-nil, toggle keywords in ~org-hidden-keywords~
+- org-appear-autoemphasis :: if non-nil and ~org-hide-emphasis-markers~ is on, toggle emphasis markers
+- org-appear-autolinks :: if non-nil and ~org-link-descriptive~ is on, toggle links
+- org-appear-autosubmarkers :: if non-nil and ~org-pretty-entities~ is on, toggle subscripts and superscripts
+- org-appear-autoentities :: if non-nil and ~org-pretty-entities~ is on, toggle Org entitites
+- org-appear-autokeywords :: if non-nil and ~org-hidden-keywords~ is on, toggle keywords in ~org-hidden-keywords~
 - org-appear-inside-latex :: if non-nil, toggle entities and sub/superscripts in LaTeX fragments
 - org-appear-delay :: seconds of delay before toggling
 - org-appear-trigger :: when to toggle elements


### PR DESCRIPTION
Thanks for this amazing package! I had wanted something like this the last time I configured my org-mode settings two years ago, and am really glad this feature now exists.

I wanted to point out that the documentation makes it sound like setting flags like `org-appear-autoemphasis` is sufficient to create the hiding/appearing functionality, but it wasn't working for me and I had to dig into the source code to find out that you also have to independently set the original org-mode flags like `org-hide-emphasis-markers` to turn on the hide functionality first. I can see now that it was implicit in the README but I think it wasn't super obvious. This PR documents the extra org-mode flags that need to be set for each type of element.